### PR TITLE
add link to footer for LFH Device Tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.2.3
++ add new link to footer for finding new Device Loan pages in school handbooks
+
 ## 2.2.2
 - remove function forcing redirect to top level on log in so deep links work
 

--- a/footer.php
+++ b/footer.php
@@ -67,6 +67,9 @@
                 <?php if (wrdsb_get_school_code()) { ?>
                     <p><a id="" style="color:white" href="<?php echo get_site_url(); ?>/trillium/classes">Class lists</a></p>
                 <?php } ?>
+                <?php if (wrdsb_get_school_code()) { ?>
+                    <p><a id="" style="color:white" href="<?php echo get_site_url(); ?>/quartermaster/device-loans/all">LFH Device Tracking</a></p>
+                <?php } ?>
                 <p><a id="footer-link-trillium-report-centre" style="color:white" target="_blank" href="http://ec-oraapp1.wrdsb.ca:8888/forms/frmservlet?config=TRRP">Trillium Report Centre</a></p>
                 <p><a id="footer-link-school-day" style="color:white" target="_blank" href="https://www.school-day.com/">School Day</a></p>
                 <p><a id="footer-link-ssr" style="color:white" href="/eguide/">Single Source Resource (eGuide)</a></p>

--- a/style.css
+++ b/style.css
@@ -3,7 +3,7 @@ Theme Name: WRDSB Staff Theme
 Theme URI: https://github.com/wrdsb/wordpress-theme-staff-intranet
 Author: Suzanne Carter, Rizwan Kiyani, James Schumann
 Description: WRDSB Theme, Staff Intranet fork
-Version: 2.2.2
+Version: 2.2.3
 License: GNU General Public License v3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 Tags: responsive-layout, three-columns, two-columns, one-column, accessibility-ready, sticky-post, custom-menu, featured-images, custom-header, fixed-layout


### PR DESCRIPTION
Just three lines. Add a link to the footer for a new feature being introduced in wordpress-plugin-staff-features.