### PR TITLE
Update text and url for footer link

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -99,7 +99,7 @@
                     <li role="presentation"><a role="treemitem" id="footer-link-class-lists" href="<?php echo get_site_url(); ?>/trillium/classes">Class lists</a></li>
                     <?php } ?>
                     <?php if (wrdsb_get_school_code()) { ?>
-                    <li><a id="footer-link-device-tracking" href="<?php echo get_site_url(); ?>/quartermaster/device-loans/all">LFH Device Tracking</a></li>
+                    <li><a id="footer-link-device-tracking" href="<?php echo get_site_url(); ?>/quartermaster/asset-assignments/all">Device Assignments</a></li>
                     <?php } ?>
                     <li><a id="footer-link-mental-health" href="/mental-health/"><img src="https://staff.wrdsb.ca/wp-content/uploads/2021/07/streamline-icon-bookmarks-document@48x48.png" class="guide-icon" alt="WRDSB Product Guide" />Mental Health Guide</a></li>
                     <li><a id="footer-link-school-day" target="_blank" href="https://www.school-day.com/">School Day</a></li>


### PR DESCRIPTION
Jeff Sanderson: "On each school handbook webpage, the link in the footer still says "LFH Device Tracking". We would like this changed to "Device Assignments""